### PR TITLE
Add buildings to kingdom

### DIFF
--- a/Main.gd
+++ b/Main.gd
@@ -23,15 +23,46 @@ var target_score_bar_value: float = 0.0
 var fill_speed = 6.0
 
 var buildings = {
-	"Peon Hut": { 
-		"level": 0, 
-		"costs": [100, 200, 400, 800, 1600] 
-	},
-	"Card Shrine": {
-		"level": 0,
-		"costs": [150, 300, 600, 1200, 2400]
-	},
-	# Add the rest later…
+        "Peon Hut": {
+                "level": 0,
+                "costs": [100, 200, 400, 800, 1600]
+        },
+        "Card Shrine": {
+                "level": 0,
+                "costs": [150, 300, 600, 1200, 2400]
+        },
+        "Barracks": {
+                "level": 0,
+                "costs": [200, 400, 800, 1600, 3200]
+        },
+        "Farm": {
+                "level": 0,
+                "costs": [120, 240, 480, 960, 1920]
+        },
+        "Blacksmith": {
+                "level": 0,
+                "costs": [250, 500, 1000, 2000, 4000]
+        },
+        "Archery Range": {
+                "level": 0,
+                "costs": [180, 360, 720, 1440, 2880]
+        },
+        "Stable": {
+                "level": 0,
+                "costs": [220, 440, 880, 1760, 3520]
+        },
+        "Wizard Tower": {
+                "level": 0,
+                "costs": [300, 600, 1200, 2400, 4800]
+        },
+        "Market": {
+                "level": 0,
+                "costs": [160, 320, 640, 1280, 2560]
+        },
+        "Wall": {
+                "level": 0,
+                "costs": [140, 280, 560, 1120, 2240]
+        }
 }
 
 func _ready():
@@ -116,11 +147,21 @@ func show_kingdom_mode():
 	show_building_ui()
 
 func show_building_ui():
-	$CanvasLayer/KingdomPanel.visible = true
-	$CanvasLayer/DrawButton.visible = false
-	$CanvasLayer/HoldButton.visible = false
-	$KingdomRoot.visible = true
-	update_all_building_buttons()
+        $CanvasLayer/KingdomPanel.visible = true
+        $CanvasLayer/DrawButton.visible = false
+        $CanvasLayer/HoldButton.visible = false
+        $KingdomRoot.visible = true
+        connect_building_buttons()
+        update_all_building_buttons()
+
+func connect_building_buttons():
+        for key in buildings.keys():
+                var btn_name = key.replace(" ", "") + "Button"
+                var btn = $CanvasLayer/KingdomPanel/BuildingList.get_node_or_null(btn_name)
+                if btn:
+                        btn.set_meta("building_key", key)
+                        if not btn.pressed.is_connected(_on_BuildingButton_pressed):
+                                btn.pressed.connect(_on_BuildingButton_pressed.bind(btn))
 
 func end_game(msg: String, gave_reward: bool):
 	result_label.text = msg
@@ -158,18 +199,33 @@ func show_reward_popup():
 func _on_restart_timer_timeout():
 	reset_game()
 
-func _on_PeonHutButton_pressed():
-	var b = buildings["Peon Hut"]
-	var lvl = b["level"]
-	if lvl < 5:
-		var cost = b["costs"][lvl]
-		if CurrencyManager.spend_coins(cost):
-			b["level"] += 1
-			buildings["Peon Hut"] = b  # Save updated level
-			$CanvasLayer/KingdomPanel/BuildingList/PeonHutLabel.text = "Peon Hut (Lv. %d)" % b["level"]
-			$KingdomRoot/PeonHut.visible = true
-			#update_building_mesh("Peon Hut", b["level"])
-			update_building_button("PeonHutButton", b)
+func _on_BuildingButton_pressed(btn: Button):
+        if not btn.has_meta("building_key"):
+                return
+
+        var key = btn.get_meta("building_key")
+        if not buildings.has(key):
+                return
+
+        var data = buildings[key]
+        var lvl = data["level"]
+        if lvl < data["costs"].size():
+                var cost = data["costs"][lvl]
+                if CurrencyManager.spend_coins(cost):
+                        data["level"] += 1
+                        buildings[key] = data
+
+                        var label_name = key.replace(" ", "") + "Label"
+                        var label = $CanvasLayer/KingdomPanel/BuildingList.get_node_or_null(label_name)
+                        if label:
+                                label.text = "%s (Lv. %d)" % [key, data["level"]]
+
+                        var node_name = key.replace(" ", "")
+                        var build_node = $KingdomRoot.get_node_or_null(node_name)
+                        if build_node:
+                                build_node.visible = true
+
+                        update_building_button(btn.name, data)
 
 
 func update_building_button(button_name: String, data: Dictionary):
@@ -177,13 +233,16 @@ func update_building_button(button_name: String, data: Dictionary):
 	if btn == null:
 		return
 
-	var lvl = data["level"]
-	if lvl < 5:
-		var cost = data["costs"][lvl]
-		btn.text = "Upgrade (%d)" % cost
-	else:
-		btn.text = "MAXED"
-		btn.disabled = true
+        var lvl = data["level"]
+        if lvl < data["costs"].size():
+                var cost = data["costs"][lvl]
+                if lvl == 0:
+                        btn.text = "Build (%d)" % cost
+                else:
+                        btn.text = "Upgrade (%d)" % cost
+        else:
+                btn.text = "MAXED"
+                btn.disabled = true
 
 func update_all_building_buttons():
 	for name in buildings.keys():

--- a/Main.tscn
+++ b/Main.tscn
@@ -148,8 +148,9 @@ text = "🏰 Kingdom"
 
 [node name="KingdomPanel" type="Panel" parent="CanvasLayer"]
 visible = false
-anchors_preset = 15
+anchor_left = 0.0
 anchor_right = 1.0
+anchor_top = 0.8
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
@@ -160,57 +161,156 @@ offset_right = 40.0
 offset_bottom = 40.0
 alignment = 1
 
-[node name="VBoxContainer" type="VBoxContainer" parent="CanvasLayer/KingdomPanel/BuildingList"]
+[node name="PeonHutContainer" type="VBoxContainer" parent="CanvasLayer/KingdomPanel/BuildingList"]
 layout_mode = 2
 
-[node name="PeonHutLabel" type="Label" parent="CanvasLayer/KingdomPanel/BuildingList/VBoxContainer"]
+[node name="PeonHutLabel" type="Label" parent="CanvasLayer/KingdomPanel/BuildingList/PeonHutContainer"]
 layout_mode = 2
-text = "Peon Hut (Lv. 1)"
+text = "Peon Hut (Lv. 0)"
 
-[node name="PeonHutButton" type="Button" parent="CanvasLayer/KingdomPanel/BuildingList/VBoxContainer"]
+[node name="PeonHutButton" type="Button" parent="CanvasLayer/KingdomPanel/BuildingList/PeonHutContainer"]
 layout_mode = 2
 text = "Build (100 Coins)"
+
+[node name="CardShrineContainer" type="VBoxContainer" parent="CanvasLayer/KingdomPanel/BuildingList"]
+layout_mode = 2
+
+[node name="CardShrineLabel" type="Label" parent="CanvasLayer/KingdomPanel/BuildingList/CardShrineContainer"]
+layout_mode = 2
+text = "Card Shrine (Lv. 0)"
+
+[node name="CardShrineButton" type="Button" parent="CanvasLayer/KingdomPanel/BuildingList/CardShrineContainer"]
+layout_mode = 2
+text = "Build (150 Coins)"
+
+[node name="BarracksContainer" type="VBoxContainer" parent="CanvasLayer/KingdomPanel/BuildingList"]
+layout_mode = 2
+
+[node name="BarracksLabel" type="Label" parent="CanvasLayer/KingdomPanel/BuildingList/BarracksContainer"]
+layout_mode = 2
+text = "Barracks (Lv. 0)"
+
+[node name="BarracksButton" type="Button" parent="CanvasLayer/KingdomPanel/BuildingList/BarracksContainer"]
+layout_mode = 2
+text = "Build (200 Coins)"
+
+[node name="FarmContainer" type="VBoxContainer" parent="CanvasLayer/KingdomPanel/BuildingList"]
+layout_mode = 2
+
+[node name="FarmLabel" type="Label" parent="CanvasLayer/KingdomPanel/BuildingList/FarmContainer"]
+layout_mode = 2
+text = "Farm (Lv. 0)"
+
+[node name="FarmButton" type="Button" parent="CanvasLayer/KingdomPanel/BuildingList/FarmContainer"]
+layout_mode = 2
+text = "Build (120 Coins)"
+
+[node name="BlacksmithContainer" type="VBoxContainer" parent="CanvasLayer/KingdomPanel/BuildingList"]
+layout_mode = 2
+
+[node name="BlacksmithLabel" type="Label" parent="CanvasLayer/KingdomPanel/BuildingList/BlacksmithContainer"]
+layout_mode = 2
+text = "Blacksmith (Lv. 0)"
+
+[node name="BlacksmithButton" type="Button" parent="CanvasLayer/KingdomPanel/BuildingList/BlacksmithContainer"]
+layout_mode = 2
+text = "Build (250 Coins)"
+
+[node name="ArcheryRangeContainer" type="VBoxContainer" parent="CanvasLayer/KingdomPanel/BuildingList"]
+layout_mode = 2
+
+[node name="ArcheryRangeLabel" type="Label" parent="CanvasLayer/KingdomPanel/BuildingList/ArcheryRangeContainer"]
+layout_mode = 2
+text = "Archery Range (Lv. 0)"
+
+[node name="ArcheryRangeButton" type="Button" parent="CanvasLayer/KingdomPanel/BuildingList/ArcheryRangeContainer"]
+layout_mode = 2
+text = "Build (180 Coins)"
+
+[node name="StableContainer" type="VBoxContainer" parent="CanvasLayer/KingdomPanel/BuildingList"]
+layout_mode = 2
+
+[node name="StableLabel" type="Label" parent="CanvasLayer/KingdomPanel/BuildingList/StableContainer"]
+layout_mode = 2
+text = "Stable (Lv. 0)"
+
+[node name="StableButton" type="Button" parent="CanvasLayer/KingdomPanel/BuildingList/StableContainer"]
+layout_mode = 2
+text = "Build (220 Coins)"
+
+[node name="WizardTowerContainer" type="VBoxContainer" parent="CanvasLayer/KingdomPanel/BuildingList"]
+layout_mode = 2
+
+[node name="WizardTowerLabel" type="Label" parent="CanvasLayer/KingdomPanel/BuildingList/WizardTowerContainer"]
+layout_mode = 2
+text = "Wizard Tower (Lv. 0)"
+
+[node name="WizardTowerButton" type="Button" parent="CanvasLayer/KingdomPanel/BuildingList/WizardTowerContainer"]
+layout_mode = 2
+text = "Build (300 Coins)"
+
+[node name="MarketContainer" type="VBoxContainer" parent="CanvasLayer/KingdomPanel/BuildingList"]
+layout_mode = 2
+
+[node name="MarketLabel" type="Label" parent="CanvasLayer/KingdomPanel/BuildingList/MarketContainer"]
+layout_mode = 2
+text = "Market (Lv. 0)"
+
+[node name="MarketButton" type="Button" parent="CanvasLayer/KingdomPanel/BuildingList/MarketContainer"]
+layout_mode = 2
+text = "Build (160 Coins)"
+
+[node name="WallContainer" type="VBoxContainer" parent="CanvasLayer/KingdomPanel/BuildingList"]
+layout_mode = 2
+
+[node name="WallLabel" type="Label" parent="CanvasLayer/KingdomPanel/BuildingList/WallContainer"]
+layout_mode = 2
+text = "Wall (Lv. 0)"
+
+[node name="WallButton" type="Button" parent="CanvasLayer/KingdomPanel/BuildingList/WallContainer"]
+layout_mode = 2
+text = "Build (140 Coins)"
 
 [node name="KingdomRoot" type="Node3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 2.39106, 0)
 
-[node name="MeshInstance3D" type="MeshInstance3D" parent="KingdomRoot"]
+[node name="PeonHut" type="MeshInstance3D" parent="KingdomRoot"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 3.22581, -2, 2)
 mesh = SubResource("BoxMesh_oe445")
 
-[node name="MeshInstance3D2" type="MeshInstance3D" parent="KingdomRoot"]
+[node name="CardShrine" type="MeshInstance3D" parent="KingdomRoot"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -3.77419, -2, 0)
 mesh = SubResource("BoxMesh_oe445")
 
-[node name="MeshInstance3D3" type="MeshInstance3D" parent="KingdomRoot"]
+[node name="Barracks" type="MeshInstance3D" parent="KingdomRoot"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2.77419, -2, 2)
 mesh = SubResource("BoxMesh_oe445")
 
-[node name="MeshInstance3D4" type="MeshInstance3D" parent="KingdomRoot"]
+[node name="Farm" type="MeshInstance3D" parent="KingdomRoot"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2.77419, -2, -2)
 mesh = SubResource("BoxMesh_oe445")
 
-[node name="MeshInstance3D5" type="MeshInstance3D" parent="KingdomRoot"]
+[node name="Blacksmith" type="MeshInstance3D" parent="KingdomRoot"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 2.22581, -2, 0)
 mesh = SubResource("BoxMesh_oe445")
 
-[node name="MeshInstance3D6" type="MeshInstance3D" parent="KingdomRoot"]
+[node name="ArcheryRange" type="MeshInstance3D" parent="KingdomRoot"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.225815, -2.10306, -4)
 mesh = SubResource("BoxMesh_oe445")
 
-[node name="MeshInstance3D7" type="MeshInstance3D" parent="KingdomRoot"]
+[node name="Stable" type="MeshInstance3D" parent="KingdomRoot"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2.06578, -2, 0)
 mesh = SubResource("BoxMesh_oe445")
 
-[node name="MeshInstance3D8" type="MeshInstance3D" parent="KingdomRoot"]
+[node name="WizardTower" type="MeshInstance3D" parent="KingdomRoot"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -5.44914, -2, 0)
 mesh = SubResource("BoxMesh_oe445")
 
-[node name="MeshInstance3D9" type="MeshInstance3D" parent="KingdomRoot"]
+[node name="Market" type="MeshInstance3D" parent="KingdomRoot"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 3.22581, -2, -2)
 mesh = SubResource("BoxMesh_oe445")
 
-[node name="MeshInstance3D10" type="MeshInstance3D" parent="KingdomRoot"]
+[node name="Wall" type="MeshInstance3D" parent="KingdomRoot"]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 4.22581, -2, 0)
 mesh = SubResource("BoxMesh_oe445")
 
@@ -224,4 +324,13 @@ mesh = SubResource("BoxMesh_qyvxw")
 [connection signal="pressed" from="CanvasLayer/DrawButton" to="." method="_on_DrawButton_pressed"]
 [connection signal="pressed" from="CanvasLayer/HoldButton" to="." method="_on_HoldButton_pressed"]
 [connection signal="pressed" from="CanvasLayer/KingdomButton" to="." method="_on_KingdomButton_pressed"]
-[connection signal="pressed" from="CanvasLayer/KingdomPanel/BuildingList/VBoxContainer/PeonHutButton" to="." method="_on_PeonHutButton_pressed"]
+[connection signal="pressed" from="CanvasLayer/KingdomPanel/BuildingList/PeonHutContainer/PeonHutButton" to="." method="_on_BuildingButton_pressed"]
+[connection signal="pressed" from="CanvasLayer/KingdomPanel/BuildingList/CardShrineContainer/CardShrineButton" to="." method="_on_BuildingButton_pressed"]
+[connection signal="pressed" from="CanvasLayer/KingdomPanel/BuildingList/BarracksContainer/BarracksButton" to="." method="_on_BuildingButton_pressed"]
+[connection signal="pressed" from="CanvasLayer/KingdomPanel/BuildingList/FarmContainer/FarmButton" to="." method="_on_BuildingButton_pressed"]
+[connection signal="pressed" from="CanvasLayer/KingdomPanel/BuildingList/BlacksmithContainer/BlacksmithButton" to="." method="_on_BuildingButton_pressed"]
+[connection signal="pressed" from="CanvasLayer/KingdomPanel/BuildingList/ArcheryRangeContainer/ArcheryRangeButton" to="." method="_on_BuildingButton_pressed"]
+[connection signal="pressed" from="CanvasLayer/KingdomPanel/BuildingList/StableContainer/StableButton" to="." method="_on_BuildingButton_pressed"]
+[connection signal="pressed" from="CanvasLayer/KingdomPanel/BuildingList/WizardTowerContainer/WizardTowerButton" to="." method="_on_BuildingButton_pressed"]
+[connection signal="pressed" from="CanvasLayer/KingdomPanel/BuildingList/MarketContainer/MarketButton" to="." method="_on_BuildingButton_pressed"]
+[connection signal="pressed" from="CanvasLayer/KingdomPanel/BuildingList/WallContainer/WallButton" to="." method="_on_BuildingButton_pressed"]


### PR DESCRIPTION
## Summary
- add 10 different building definitions
- expose building buttons dynamically and connect them
- rename mesh placeholders with building names
- add bottom panel showing all buildings

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870bfabecd4832da9f8d36092be6b58