### PR TITLE
Add separate kingdom scenes

### DIFF
--- a/Kingdom1.tscn
+++ b/Kingdom1.tscn
@@ -1,0 +1,45 @@
+[gd_scene format=4]
+
+[sub_resource type="BoxMesh" id="BoxMesh_default"]
+
+[node name="KingdomRoot" type="Node3D"]
+
+[node name="PeonHut" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_default")
+visible = false
+
+[node name="CardShrine" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_default")
+visible = false
+
+[node name="Barracks" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_default")
+visible = false
+
+[node name="Farm" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_default")
+visible = false
+
+[node name="Blacksmith" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_default")
+visible = false
+
+[node name="ArcheryRange" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_default")
+visible = false
+
+[node name="Stable" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_default")
+visible = false
+
+[node name="WizardTower" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_default")
+visible = false
+
+[node name="Market" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_default")
+visible = false
+
+[node name="Wall" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_default")
+visible = false

--- a/Kingdom2.tscn
+++ b/Kingdom2.tscn
@@ -1,0 +1,45 @@
+[gd_scene format=4]
+
+[sub_resource type="BoxMesh" id="BoxMesh_default"]
+
+[node name="KingdomRoot" type="Node3D"]
+
+[node name="PeonHut" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_default")
+visible = false
+
+[node name="CardShrine" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_default")
+visible = false
+
+[node name="Barracks" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_default")
+visible = false
+
+[node name="Farm" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_default")
+visible = false
+
+[node name="Blacksmith" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_default")
+visible = false
+
+[node name="ArcheryRange" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_default")
+visible = false
+
+[node name="Stable" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_default")
+visible = false
+
+[node name="WizardTower" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_default")
+visible = false
+
+[node name="Market" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_default")
+visible = false
+
+[node name="Wall" type="MeshInstance3D" parent="."]
+mesh = SubResource("BoxMesh_default")
+visible = false

--- a/Main.gd
+++ b/Main.gd
@@ -33,16 +33,18 @@ var current_kingdom_idx: int = 0
 var buildings: Dictionary = {}
 
 func setup_kingdoms():
-	kingdoms.clear()
-	var k1 = KingdomData.new()
-	k1.name = "Kingdom 1"
-	k1.buildings = KingdomData.default_buildings()
-	kingdoms.append(k1)
+        kingdoms.clear()
+        var k1 = KingdomData.new()
+        k1.name = "Kingdom 1"
+        k1.scene_path = "res://Kingdom1.tscn"
+        k1.buildings = KingdomData.default_buildings()
+        kingdoms.append(k1)
 
-	var k2 = KingdomData.new()
-	k2.name = "Kingdom 2"
-	k2.buildings = KingdomData.default_buildings()
-	kingdoms.append(k2)
+        var k2 = KingdomData.new()
+        k2.name = "Kingdom 2"
+        k2.scene_path = "res://Kingdom2.tscn"
+        k2.buildings = KingdomData.default_buildings()
+        kingdoms.append(k2)
 
 func load_kingdom(index: int):
 	if index >= kingdoms.size():
@@ -57,28 +59,32 @@ func load_kingdom(index: int):
 			"costs": entry.get("costs", []).duplicate()
 		}
 
-	var old_root = get_node_or_null("KingdomRoot")
-	var new_root: Node3D = null
-	if data.scene_path != "":
-		var scene = load(data.scene_path)
-		if scene:
-			new_root = scene.instantiate()
-	if new_root == null:
-		new_root = Node3D.new()
-	new_root.name = "KingdomRoot"
-	if old_root:
-		remove_child(old_root)
-		old_root.queue_free()
-	add_child(new_root)
+        var old_root = get_node_or_null("KingdomRoot")
+        if old_root:
+                old_root.queue_free()
+
+        var new_root: Node3D = null
+        if data.scene_path != "":
+                var scene = load(data.scene_path)
+                if scene:
+                        new_root = scene.instantiate()
+        if new_root == null:
+                new_root = Node3D.new()
+        new_root.name = "KingdomRoot"
+        add_child(new_root)
 
 	for key in buildings.keys():
 		var label = get_building_label(key)
 		if label:
 			label.text = "%s (Lv. %d)" % [key, buildings[key]["level"]]
 
-	for building in new_root.get_children():
-		var key = building.name.replace("_", " ")
-		building.visible = buildings.has(key) and buildings[key]["level"] > 0
+        for building in new_root.get_children():
+                building.visible = false
+
+        for building in new_root.get_children():
+                var key = building.name.replace("_", " ")
+                if buildings.has(key) and buildings[key]["level"] > 0:
+                        building.visible = true
 
 	connect_building_buttons()
 	update_all_building_buttons()


### PR DESCRIPTION
## Summary
- create basic 3D scene files `Kingdom1.tscn` and `Kingdom2.tscn`
- store scene paths in `KingdomData` objects
- reload the proper scene when switching kingdoms
- hide all building nodes until constructed

## Testing
- `true` *(no tests provided)*
- `apt-get update` *(failed: domain is not in allowlist)*

------
https://chatgpt.com/codex/tasks/task_e_68735fcc991c832d974e296dd167633f