### PR TITLE
Enable physics-based card movement

### DIFF
--- a/Card3D.gd
+++ b/Card3D.gd
@@ -1,30 +1,17 @@
-extends Node3D
+extends RigidBody3D
 
 @export var value: int = 0
-@export var target_position: Vector3
 
 var label_assigned := false
 
 func set_target_position(pos: Vector3):
-	target_position = pos
-	if is_inside_tree():
-		animate_to_position()
-	else:
-		await ready
-		animate_to_position()
-
-func animate_to_position():
-	var tween = get_tree().create_tween()
-	tween.tween_property(self, "global_position", target_position, 0.4).set_trans(Tween.TRANS_CUBIC).set_ease(Tween.EASE_OUT)
+	var dir = pos - global_position
+	dir.y = 0
+	var impulse = dir.normalized() * 5.0
+	apply_impulse(Vector3.ZERO, impulse)
 
 func _ready():
-	set_process(true)
 	update_label()
-
-func _process(delta):
-	global_position = global_position.lerp(target_position, delta * 5.0)
-	if not label_assigned:
-		update_label()
 
 func update_label():
 	if has_node("ValueLabel"):

--- a/Card3D.tscn
+++ b/Card3D.tscn
@@ -1,11 +1,17 @@
-[gd_scene load_steps=3 format=3 uid="uid://bqiltepaituur"]
+[gd_scene load_steps=4 format=3 uid="uid://bqiltepaituur"]
 
 [ext_resource type="Script" uid="uid://c8xbm7nysu3da" path="res://Card3D.gd" id="1_eeaw3"]
 
 [sub_resource type="BoxMesh" id="BoxMesh_axxlu"]
 
-[node name="Card3D" type="Node3D"]
+[sub_resource type="BoxShape3D" id="BoxShape_card"]
+size = Vector3(0.9, 0.05, 1.0)
+
+[node name="Card3D" type="RigidBody3D"]
 script = ExtResource("1_eeaw3")
+
+[node name="CollisionShape3D" type="CollisionShape3D" parent="."]
+shape = SubResource("BoxShape_card")
 
 [node name="MeshInstance3D" type="CSGMesh3D" parent="."]
 transform = Transform3D(0.91, 0, 0, 0, 0.021, 0, 0, 0, 1.0008, 0, 0.0225056, 0)

--- a/Main.gd
+++ b/Main.gd
@@ -232,10 +232,11 @@ func give_reward(reward: Dictionary):
 
 
 func _position_new_card(card):
-	var target_x = float(cards.size() - 1) * 0.25
-	var target_y = float(cards.size() - 1) * 0.025
-	var target_z = randf_range(-0.025, 0.025)
-	card.target_position = card_row.global_transform.origin + Vector3(target_x, target_y, target_z)
+        var target_x = float(cards.size() - 1) * 0.25
+        var target_y = float(cards.size() - 1) * 0.025
+        var target_z = randf_range(-0.025, 0.025)
+        var pos = card_row.global_transform.origin + Vector3(target_x, target_y, target_z)
+        card.set_target_position(pos)
 
 
 func start_auto_draw():
@@ -258,8 +259,8 @@ func draw_card():
 	score_label.text = "Score: " + str(current_score)
 
 	var card = card_scene.instantiate()
-	card.value = value
-	card.global_position = card_spawn.global_position
+        card.value = value
+        card.global_position = card_spawn.global_position + Vector3(0, 1, 0)
 	card_row.add_child(card)
 	cards.append(card)
 


### PR DESCRIPTION
## Summary
- use a `RigidBody3D` root in `Card3D.tscn`
- add a collision shape so cards collide with tables
- convert `Card3D.gd` to drive movement with an impulse
- spawn cards slightly above the table and apply an impulse towards their target location
- ensure kingdom scenes keep table colliders for card physics
- fix indentation issues in `Card3D.gd`

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885c6416e4c832dbf7568333ac35b90