### PR TITLE
Refactor card table into dedicated scene

### DIFF
--- a/CardTable.gd
+++ b/CardTable.gd
@@ -1,0 +1,111 @@
+extends Node3D
+
+@onready var card_scene = preload("res://Card3D.tscn")
+@onready var card_row = $CardRow
+@onready var card_spawn = $CardSpawn
+@onready var draw_button = $CanvasLayer/DrawButton
+@onready var hold_button = $CanvasLayer/HoldButton
+@onready var score_label = $CanvasLayer/ScoreLabel
+@onready var total_label = $CanvasLayer/TotalScoreLabel
+@onready var restart_timer = $CanvasLayer/RestartTimer
+
+var current_score = 0
+var total_score = 0
+var cards = []
+var icon_counts: Dictionary = {}
+var available_icons := ["attack", "shield", "gold", "pillage", "special_item"]
+var icon_textures = {
+    "attack": preload("res://item_icons/attack_256_256.png"),
+    "shield": preload("res://item_icons/shield_256_256.png"),
+    "gold": preload("res://item_icons/gold_256_256.png"),
+    "pillage": preload("res://item_icons/pillage_256_256.png"),
+    "special_item": preload("res://item_icons/special_item_256_256.png"),
+}
+
+func draw_card():
+    if current_score == 0:
+        if not CurrencyManager.spend_draw(1):
+            return
+    var value = randi() % 6 + 1
+    current_score += value
+    hold_button.disabled = current_score < 18
+    score_label.text = "Score: " + str(current_score)
+
+    var card = card_scene.instantiate()
+    card.value = value
+
+    var icon_type = available_icons[randi() % available_icons.size()]
+    if icon_textures.has(icon_type):
+        card.icon_texture = icon_textures[icon_type]
+    if "icon_type" in card:
+        card.icon_type = icon_type
+    icon_counts[icon_type] = icon_counts.get(icon_type, 0) + 1
+    if icon_counts[icon_type] == 3:
+        print("Collected three %s icons" % icon_type)
+
+    var i = cards.size()
+    var col = i % 4
+    var row = i / 4
+    card.global_position = card_spawn.global_position + Vector3(col * 0.5, row * 1.5, row + 2.0)
+
+    card_row.add_child(card)
+    cards.append(card)
+
+    call_deferred("_finalize_card_position", card)
+
+    if current_score == 21:
+        total_score += 50
+        end_game("🎉 Jackpot! +50", true)
+    elif current_score > 21:
+        end_game("💥 Bust!", false)
+
+func _finalize_card_position(card):
+    if not card_row.is_inside_tree():
+        await get_tree().process_frame
+
+    var i = cards.size() - 1
+    var col = i % 4
+    var row = i / 4
+    var base_pos = card_row.global_transform.origin
+
+    var spacing = Vector3(0.9, -0.5, 0)
+    var offset = Vector3(col, row, 0) * spacing
+
+    var rand_offset = Vector3(
+        randf_range(-0.1, 0.1),
+        randf_range(-0.1, 0.1),
+        randf_range(-0.1, 0.1)
+    )
+
+    card.set_target_position(base_pos + offset + rand_offset)
+
+    card.rotation_degrees = Vector3(
+        randf_range(-10, 10),
+        randf_range(-10, 10),
+        randf_range(-10, 10)
+    )
+
+func _on_DrawButton_pressed():
+    draw_button.disabled = true
+    hold_button.disabled = true
+    draw_card()
+
+    while current_score < 15 and restart_timer.is_stopped():
+        await get_tree().create_timer(0.1).timeout
+        draw_card()
+    if restart_timer.is_stopped():
+        draw_button.disabled = false
+        hold_button.disabled = current_score < 18
+
+func _on_HoldButton_pressed():
+    if current_score >= 18:
+        total_score += current_score
+        end_game("👍 Scored " + str(current_score), true)
+    else:
+        end_game("😐 Low score...", false)
+
+func end_game(msg: String, gave_reward: bool):
+    total_label.text = "Total: " + str(total_score)
+    draw_button.disabled = true
+    hold_button.disabled = true
+    restart_timer.start()

--- a/Main.gd
+++ b/Main.gd
@@ -262,76 +262,6 @@ func start_auto_draw():
 		$CanvasLayer/DrawButton.disabled = false
 		$CanvasLayer/HoldButton.disabled = current_score < 18
 	
-func draw_card():
-	if current_score == 0:
-		if not CurrencyManager.spend_draw(1):
-			return
-	var value = randi() % 6 + 1
-	current_score += value
-	hold_button.disabled = current_score < 18
-	score_label.text = "Score: " + str(current_score)
-
-	var card = card_scene.instantiate()
-	card.value = value
-	
-	var icon_type = available_icons[randi() % available_icons.size()]
-	if icon_textures.has(icon_type):
-		card.icon_texture = icon_textures[icon_type]
-	if "icon_type" in card:
-		card.icon_type = icon_type
-	icon_counts[icon_type] = icon_counts.get(icon_type, 0) + 1
-	if icon_counts[icon_type] == 3:
-		print("Collected three %s icons" % icon_type)
-	
-	var i  = cards.size()
-	var col = i % 4
-	var row = i/4
-	card.global_position = card_spawn.global_position +  Vector3(col * 0.5,  row * 1.5, row + 2.0)
-	
-	card_row.add_child(card)
-	cards.append(card)
-
-	call_deferred("_finalize_card_position", card)
-
-	if current_score == 21:
-		total_score += 50
-		end_game("🎉 Jackpot! +50", true)
-	elif current_score > 21:
-		end_game("💥 Bust!", false)
-
-func _finalize_card_position(card):
-	if not card_row.is_inside_tree():
-		await get_tree().process_frame
-		
-	var i = cards.size() -1
-	var col = i % 4
-	var row = i / 4
-	var base_pos = card_row.global_transform.origin
-	
-	var spacing = Vector3(0.9, -0.5, 0)
-	var offset = Vector3(col, row, 0) * spacing
-	
-	var rand_offset = Vector3(
-		randf_range(-0.1, 0.1),
-		randf_range(-0.1, 0.1),
-		randf_range(-0.1, 0.1)
-	)
-	
-	card.set_target_position(base_pos + offset + rand_offset)
-	
-	card.rotation_degrees = Vector3(
-		randf_range(-10, 10),
-		randf_range(-10, 10),
-		randf_range(-10, 10)
-	)
-	
-
-func _on_HoldButton_pressed():
-	if current_score >= 18:
-		total_score += current_score
-		end_game("👍 Scored " + str(current_score), true)
-	else:
-		end_game("😐 Low score...", false)
 
 func _on_KingdomButton_pressed():
 	show_kingdom_mode()
@@ -517,20 +447,6 @@ func _on_AutoDrawTimer_timeout():
 	else:
 		auto_draw_timer.start()
 
-func _on_DrawButton_pressed():
-	if auto_draw_enabled:
-		start_auto_draw()
-	else:
-		draw_button.disabled = true
-		hold_button.disabled = true
-		draw_card()
-			
-		while current_score < 15 and restart_timer.is_stopped():
-			await get_tree().create_timer(0.1).timeout
-			draw_card()
-		if restart_timer.is_stopped():
-			draw_button.disabled = false
-			hold_button.disabled = current_score < 18
 
 func _on_AutoToggleButton_pressed():
 	auto_draw_enabled = !auto_draw_enabled

--- a/Main.tscn
+++ b/Main.tscn
@@ -338,9 +338,7 @@ text = "Wall (Lv. 0)"
 layout_mode = 2
 text = "Build (140 Coins)"
 
-[connection signal="pressed" from="CanvasLayer/DrawButton" to="." method="_on_DrawButton_pressed"]
 [connection signal="pressed" from="CanvasLayer/AutoToggleButton" to="." method="_on_AutoToggleButton_pressed"]
-[connection signal="pressed" from="CanvasLayer/HoldButton" to="." method="_on_HoldButton_pressed"]
 [connection signal="timeout" from="CanvasLayer/AutoDrawTimer" to="." method="_on_AutoDrawTimer_timeout"]
 [connection signal="pressed" from="CanvasLayer/KingdomButton" to="." method="_on_KingdomButton_pressed"]
 [connection signal="pressed" from="CanvasLayer/KingdomPanel/ScrollContainer/BuildingList/WallContainer/WallButton" to="." method="_on_BuildingButton_pressed"]

--- a/card_table.tscn
+++ b/card_table.tscn
@@ -1,5 +1,6 @@
-[gd_scene load_steps=23 format=3 uid="uid://dfkgd251da7vy"]
+[gd_scene load_steps=24 format=3 uid="uid://dfkgd251da7vy"]
 
+[ext_resource type="Script" path="res://CardTable.gd" id="1_vn8pc"]
 [ext_resource type="PackedScene" uid="uid://m222llrppvl2" path="res://assets/models/building/floor_stone.glb" id="2_tk758"]
 [ext_resource type="PackedScene" uid="uid://dk8ngwlaasy1b" path="res://assets/card_table.tscn" id="3_a57dv"]
 [ext_resource type="PackedScene" uid="uid://byqffxe6glphu" path="res://assets/models/props/torch_mounted.glb" id="4_043sh"]
@@ -24,6 +25,65 @@
 [ext_resource type="PackedScene" uid="uid://bofghkh3f8hxg" path="res://assets/misc/KayKit_Adventurers_1.0_FREE/Characters/gltf/Rogue_Hooded.glb" id="21_2jkan"]
 
 [node name="CardTable" type="Node3D"]
+script = ExtResource("1_vn8pc")
+
+[node name="CardSpawn" type="Marker3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -0.0224791, 1.66567, -2.30465)
+
+[node name="DeckSpawn" type="Marker3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0.0164801, 1.00785, -0.34959)
+
+[node name="CardRow" type="Node3D" parent="."]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -1, 0.122254, 0)
+
+[node name="CanvasLayer" type="CanvasLayer" parent="."]
+
+[node name="ScoreLabel" type="Label" parent="CanvasLayer"]
+offset_left = 300.0
+offset_top = 260.0
+offset_right = 432.0
+offset_bottom = 309.0
+theme_override_font_sizes/font_size = 35
+text = "Score: 0"
+horizontal_alignment = 1
+
+[node name="TotalScoreLabel" type="Label" parent="CanvasLayer"]
+offset_left = 20.0
+offset_top = 320.0
+offset_right = 60.0
+offset_bottom = 343.0
+
+[node name="DrawButton" type="Button" parent="CanvasLayer"]
+anchors_preset = 7
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_left = -200.0
+offset_top = -260.0
+offset_right = -20.0
+offset_bottom = -100.0
+grow_horizontal = 2
+grow_vertical = 0
+theme_override_font_sizes/font_size = 50
+text = "DRAW"
+
+[node name="HoldButton" type="Button" parent="CanvasLayer"]
+anchors_preset = 7
+anchor_left = 0.5
+anchor_top = 1.0
+anchor_right = 0.5
+anchor_bottom = 1.0
+offset_top = -260.0
+offset_right = 180.0
+offset_bottom = -100.0
+grow_horizontal = 2
+grow_vertical = 0
+theme_override_font_sizes/font_size = 50
+text = "HOLD"
+
+[node name="RestartTimer" type="Timer" parent="CanvasLayer"]
+one_shot = true
 
 [node name="Chest" parent="." instance=ExtResource("5_ud6sj")]
 transform = Transform3D(0.63388, 0, 0.773431, 0, 1, 0, -0.773431, 0, 0.63388, 1.97483, 0, 7.39904)
@@ -194,3 +254,6 @@ transform = Transform3D(-0.707107, 0, -0.707107, 0, 1, 0, 0.707107, 0, -0.707107
 
 [node name="Rogue_Hooded" parent="." instance=ExtResource("21_2jkan")]
 transform = Transform3D(-0.866025, 0, 0.5, 0, 1, 0, -0.5, 0, -0.866025, -5, 0, 8)
+
+[connection signal="pressed" from="CanvasLayer/DrawButton" to="." method="_on_DrawButton_pressed"]
+[connection signal="pressed" from="CanvasLayer/HoldButton" to="." method="_on_HoldButton_pressed"]


### PR DESCRIPTION
## Summary
- Attach CardTable.gd to card_table scene with spawn markers and card UI
- Move card draw and hold logic from Main.gd into CardTable.gd
- Remove obsolete button connections from main scene

## Testing
- `godot3-runner --path . --headless` *(fails: Can't open project, config_version 5 is newer than expected)*

------
https://chatgpt.com/codex/tasks/task_e_688db7d2dce0832d866d785dc2ac42ca