### PR TITLE
Delegate auto-draw to card table

### DIFF
--- a/Main.gd
+++ b/Main.gd
@@ -468,22 +468,22 @@ func _unhandled_input(event):
 
 
 func _on_AutoDrawTimer_timeout():
-	if not auto_draw_enabled:
-		auto_draw_timer.stop()
-		return
+        if not auto_draw_enabled:
+                auto_draw_timer.stop()
+                return
 
-	draw_card()
-	hold_button.disabled = current_score < 18
-	if current_score >= 21:
-		return
-	
-	if current_score >= 18:
-		if randi() % 2 == 0:
-			_on_HoldButton_pressed()
-		else:
-			auto_draw_timer.start()
-	else:
-		auto_draw_timer.start()
+        card_table_root.draw_card()
+        hold_button.disabled = card_table_root.current_score < 18
+        if card_table_root.current_score >= 21:
+                return
+
+        if card_table_root.current_score >= 18:
+                if randi() % 2 == 0:
+                        card_table_root._on_HoldButton_pressed()
+                else:
+                        auto_draw_timer.start()
+        else:
+                auto_draw_timer.start()
 
 
 func _on_AutoToggleButton_pressed():


### PR DESCRIPTION
## Summary
- Route auto-draw timer actions through `card_table_root` so the main node leverages the card table's logic
- Ensure auto-draw decisions use the card table's score and hold logic

## Testing
- `godot3 --headless --check project.godot` *(fails: project uses newer Godot version)*

------
https://chatgpt.com/codex/tasks/task_e_688efec63c00832d92cc3f4b4c700836