### PR TITLE
feat: add currency labels to card table

### DIFF
--- a/CurrencyManager.gd
+++ b/CurrencyManager.gd
@@ -11,18 +11,19 @@ var stars: int = 0
 @onready var star_label = null
 
 func _ready():
-	var root = get_tree().root
-	if root.has_node("Main/CanvasLayer/CoinLabel"):
-		coin_label = root.get_node("Main/CanvasLayer/CoinLabel")
-	if root.has_node("Main/CanvasLayer/DrawLabel"):
-		draw_label = root.get_node("Main/CanvasLayer/DrawLabel")
-	if root.has_node("Main/CanvasLayer/GemLabel"):
-		gem_label = root.get_node("Main/CanvasLayer/GemLabel")
-	if root.has_node("Main/CanvasLayer/StarLabel"):
-		star_label = root.get_node("Main/CanvasLayer/StarLabel")
-	
-	#update_coin_ui()
-	update_all_ui()
+        get_tree().connect("scene_changed", Callable(self, "_on_scene_changed"))
+        _on_scene_changed(get_tree().current_scene)
+
+func _on_scene_changed(scene):
+        var root = get_tree().root
+        var base_path = "Main/CanvasLayer"
+        if scene and scene.name == "CardTable":
+                base_path = "CardTable/CanvasLayer"
+        coin_label = root.get_node_or_null(base_path + "/CoinLabel")
+        draw_label = root.get_node_or_null(base_path + "/DrawLabel")
+        gem_label = root.get_node_or_null(base_path + "/GemLabel")
+        star_label = root.get_node_or_null(base_path + "/StarLabel")
+        update_all_ui()
 
 func add_currency(type: String, amount: int):
 	match type:

--- a/card_table.tscn
+++ b/card_table.tscn
@@ -38,6 +38,26 @@ transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2, 2.2, 6)
 
 [node name="CanvasLayer" type="CanvasLayer" parent="."]
 
+[node name="CoinLabel" type="Label" parent="CanvasLayer"]
+offset_left = 20.0
+offset_top = 20.0
+text = "\U0001fa99 Coins: 0"
+
+[node name="DrawLabel" type="Label" parent="CanvasLayer"]
+offset_left = 20.0
+offset_top = 40.0
+text = "\U0001f3af Draws: 0"
+
+[node name="GemLabel" type="Label" parent="CanvasLayer"]
+offset_left = 20.0
+offset_top = 60.0
+text = "\U0001f48e Gems: 0"
+
+[node name="StarLabel" type="Label" parent="CanvasLayer"]
+offset_left = 20.0
+offset_top = 80.0
+text = "\u2b50 Stars: 0"
+
 [node name="ScoreLabel" type="Label" parent="CanvasLayer"]
 offset_left = 300.0
 offset_top = 260.0


### PR DESCRIPTION
## Summary
- show coin, draw, gem, and star values in card table UI
- update CurrencyManager to retarget UI nodes when scene changes and refresh values

## Testing
- `godot3 --version`
- `godot3 --headless --quit` *(fails: Can't open project at '/workspace/mobile_game/project.godot', its `config_version` (5) is from a more recent and incompatible version of the engine)*

------
https://chatgpt.com/codex/tasks/task_e_68923586f1ac832daeb7e82f747f4416