### PR TITLE
Align card flip axis with spawn rotation

### DIFF
--- a/Card3D.gd
+++ b/Card3D.gd
@@ -35,15 +35,16 @@ func throw_to(target_pos: Vector3):
 	
 
 func throw_with_physics(target_pos: Vector3):
-	var launch = target_pos - global_position
-	launch.y += 1.0
-	var dir = launch.normalized()
-	linear_velocity = dir * 0.5
-	apply_impulse(Vector3.ZERO, dir * 2.0)
-	apply_torque_impulse(Vector3(0.0, 0.0, -3.0))
-	front_shown =  false
-	landed = false
-	linear_damp = 0.5
+        var launch = target_pos - global_position
+        launch.y += 1.0
+        var dir = launch.normalized()
+        linear_velocity = dir * 0.5
+        apply_impulse(Vector3.ZERO, dir * 2.0)
+       rotation_degrees = Vector3(0, 0, 180)
+       apply_torque_impulse(Vector3(0.0, 0.0, -3.0))
+        front_shown =  false
+        landed = false
+        linear_damp = 0.5
 	
 
 func _physics_process(_delta):

--- a/CardTable.gd
+++ b/CardTable.gd
@@ -93,14 +93,13 @@ func draw_card():
 	if icon_counts[icon_type] == 3:
 		print("Collected three %s icons" % icon_type)
 	
-	card.global_transform.origin = card_spawn.global_position
-	card.rotation_degrees = Vector3(90,0,0)
-	
-	card_row.add_child(card)
-	card.global_position = card_spawn.global_position
-	card.rotation_degrees = Vector3(180, 0, 0)
-	cards.append(card)
-	call_deferred("_finalize_card_position", card)
+       card.global_transform.origin = card_spawn.global_position
+       card.rotation_degrees = Vector3(0, 0, 180)
+
+       card_row.add_child(card)
+       card.global_position = card_spawn.global_position
+       cards.append(card)
+       call_deferred("_finalize_card_position", card)
 	
 	if current_score == 21:
 		total_score += 50


### PR DESCRIPTION
## Summary
- Spawn cards with 180° rotation on the Z-axis to match flip behavior
- Ensure `throw_with_physics` sets initial rotation and torque around Z
- Show card front only after Z rotation passes 90°

## Testing
- `godot --headless --version` *(fails: command not found)*
- `apt-get install -y godot3` *(attempted to install missing dependency)*

------
https://chatgpt.com/codex/tasks/task_e_6896ef22f904832d82389d20f0e7dd97