### PR TITLE
Increase friction on card and table materials

### DIFF
--- a/Card3D.tscn
+++ b/Card3D.tscn
@@ -3,8 +3,8 @@
 [ext_resource type="Script" uid="uid://c8xbm7nysu3da" path="res://Card3D.gd" id="1_eeaw3"]
 
 [sub_resource type="PhysicsMaterial" id="PhysicsMaterial_eeaw3"]
-friction = 0.1
-bounce = 0.1
+friction = 0.5
+bounce = 0.05
 
 [sub_resource type="StandardMaterial3D" id="StandardMaterial3D_1810p"]
 

--- a/assets/card_table.tscn
+++ b/assets/card_table.tscn
@@ -3,8 +3,8 @@
 [ext_resource type="PackedScene" uid="uid://jlrji8gbqcoy" path="res://assets/models/props/table_medium.glb" id="1_coeb0"]
 
 [sub_resource type="PhysicsMaterial" id="PhysicsMaterial_coeb0"]
-friction = 0.1
-bounce = 0.1
+friction = 0.5
+bounce = 0.05
 
 [sub_resource type="BoxShape3D" id="BoxShape3D_8h5ek"]
 size = Vector3(3.02101, 0.997131, 2.98854)


### PR DESCRIPTION
## Summary
- Raise friction on card physics material to resist sliding and reduce bounce
- Increase table friction with reduced bounce for more realistic interactions

## Testing
- `godot --headless --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896f0ef8f60832dba1814302a9d3840