### PR TITLE
Align card spawn with camera

### DIFF
--- a/CardTable.gd
+++ b/CardTable.gd
@@ -2,7 +2,8 @@ extends Node3D
 
 @onready var card_scene = preload("res://Card3D.tscn")
 @onready var card_row = $CardRow
-@onready var card_spawn = $CardSpawn
+@onready var camera = $Camera3D
+@onready var card_spawn = $Camera3D/CardSpawn
 @onready var draw_button = $CanvasLayer/DrawButton
 @onready var hold_button = $CanvasLayer/HoldButton
 @onready var score_label = $CanvasLayer/ScoreLabel
@@ -82,31 +83,39 @@ func draw_card():
 	hold_button.disabled = current_score < 18
 	score_label.text = "Score: " + str(current_score)
 
-	var card = card_scene.instantiate()
-	card.value = value
-	var icon_type = available_icons[randi() % available_icons.size()]
-	if icon_textures.has(icon_type):
-		card.icon_texture = icon_textures[icon_type]
-	if "icon_type" in card:
-		card.icon_type = icon_type
-	icon_counts[icon_type] = icon_counts.get(icon_type, 0) + 1
-	if icon_counts[icon_type] == 3:
-		print("Collected three %s icons" % icon_type)
-	
-	card.global_transform.origin = card_spawn.global_position
-	card.rotation_degrees = Vector3(90,0,0)
-	
-	card_row.add_child(card)
-	card.global_position = card_spawn.global_position
-	card.rotation_degrees = Vector3(180, 0, 0)
-	cards.append(card)
-	call_deferred("_finalize_card_position", card)
-	
-	if current_score == 21:
-		total_score += 50
-		end_game("🎉 Jackpot! +50", true)
-	elif current_score > 21:
-		end_game("💥 Bust!", false)
+        var card = card_scene.instantiate()
+        card.value = value
+        var icon_type = available_icons[randi() % available_icons.size()]
+        if icon_textures.has(icon_type):
+                card.icon_texture = icon_textures[icon_type]
+        if "icon_type" in card:
+                card.icon_type = icon_type
+        icon_counts[icon_type] = icon_counts.get(icon_type, 0) + 1
+        if icon_counts[icon_type] == 3:
+                print("Collected three %s icons" % icon_type)
+
+        var spawn_transform = _get_spawn_transform()
+        card_spawn.global_transform = spawn_transform
+        card_row.add_child(card)
+        card.global_transform = spawn_transform
+        card.rotation_degrees = Vector3(180, 0, 0)
+        cards.append(card)
+        call_deferred("_finalize_card_position", card)
+
+        if current_score == 21:
+                total_score += 50
+                end_game("🎉 Jackpot! +50", true)
+        elif current_score > 21:
+                end_game("💥 Bust!", false)
+
+
+func _get_spawn_transform() -> Transform3D:
+        var viewport_size = get_viewport().get_visible_rect().size
+        var screen_pos = Vector2(viewport_size.x * 0.5, viewport_size.y * 0.9)
+        var origin = camera.project_ray_origin(screen_pos)
+        var dir = camera.project_ray_normal(screen_pos)
+        var position = origin + dir * 2.0
+        return Transform3D(camera.global_transform.basis, position)
 
 
 func _finalize_card_position(card):

--- a/card_table.tscn
+++ b/card_table.tscn
@@ -27,8 +27,8 @@
 [node name="CardTable" type="Node3D"]
 script = ExtResource("1_vn8pc")
 
-[node name="CardSpawn" type="Marker3D" parent="."]
-transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2, 2.51692, 3)
+[node name="CardSpawn" type="Marker3D" parent="Camera3D"]
+transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -2, -3)
 
 [node name="CardRow" type="Node3D" parent="."]
 transform = Transform3D(1, 0, 0, 0, 1, 0, 0, 0, 1, -2.96023, 1.10593, 5.99826)


### PR DESCRIPTION
## Summary
- Anchor CardSpawn under the camera so spawned cards appear from the bottom of the view
- Calculate spawn transform from camera and viewport to keep layout consistent across resolutions

## Testing
- `godot3 --headless --quit` *(fails: project.godot uses config version 5, incompatible with engine)*


------
https://chatgpt.com/codex/tasks/task_e_6896f0f09534832db4178136bb8b8c58