### PR TITLE
Handle missing card spawn or card nodes safely

### DIFF
--- a/CardTable.gd
+++ b/CardTable.gd
@@ -95,12 +95,14 @@ func draw_card():
                 print("Collected three %s icons" % icon_type)
 
         var spawn_transform = _get_spawn_transform()
-        card_spawn.global_transform = spawn_transform
-        card_row.add_child(card)
-        card.global_transform = spawn_transform
-        card.rotation_degrees = Vector3(180, 0, 0)
-        cards.append(card)
-        call_deferred("_finalize_card_position", card)
+        if card_spawn:
+                card_spawn.global_transform = spawn_transform
+        if card:
+                card_row.add_child(card)
+                card.global_transform = spawn_transform
+                card.rotation_degrees = Vector3(180, 0, 0)
+                cards.append(card)
+                call_deferred("_finalize_card_position", card)
 
         if current_score == 21:
                 total_score += 50


### PR DESCRIPTION
## Summary
- Ensure card draw handles missing `CardSpawn` gracefully
- Check for null `card` before assigning transforms
- Confirm `CardSpawn` marker exists in scene

## Testing
- `godot3 --headless --check project.godot` *(fails: project uses newer engine config)*

------
https://chatgpt.com/codex/tasks/task_e_68971a5636c0832d984b2a0a624720f6