### PR TITLE
Add angular damping after card collisions

### DIFF
--- a/Card3D.gd
+++ b/Card3D.gd
@@ -8,6 +8,7 @@ var label_assigned := false
 var front_shown := false
 var landed := false
 var slide_damp := 0.5
+@export var angular_slide_damp: float = 10.0
 
 
 func set_target_position(pos: Vector3):
@@ -18,40 +19,45 @@ func set_target_position(pos: Vector3):
 
 
 func _ready():
-	linear_damp = slide_damp
+        linear_damp = slide_damp
+        angular_damp = 0.1
 
 
 func throw_to(target_pos: Vector3):
-	var launch = target_pos - global_position
-	launch.y += 1.0
-	var dir = launch.normalized()
-	linear_velocity = dir * 0.5
-	apply_impulse(Vector3.ZERO, dir * 2.0)
-	rotation_degrees.z = 180.0
-	angular_velocity = Vector3(0.0, 0.0, -3.0)
-	front_shown = false
-	landed = false
-	linear_damp = slide_damp
+        var launch = target_pos - global_position
+        launch.y += 1.0
+        var dir = launch.normalized()
+        linear_velocity = dir * 0.5
+        apply_impulse(Vector3.ZERO, dir * 2.0)
+        rotation_degrees.z = 180.0
+        angular_velocity = Vector3(0.0, 0.0, -3.0)
+        front_shown = false
+        landed = false
+        linear_damp = slide_damp
+        angular_damp = 0.1
 
 
 func throw_with_physics(target_pos: Vector3):
-	var launch = target_pos - global_position
-	launch.y += 1.0
-	var dir = launch.normalized()
-	linear_velocity = dir * 0.5
-	apply_impulse(Vector3.ZERO, dir * 2.0)
-	apply_torque_impulse(Vector3(0.0, 0.0, -3.0))
-	front_shown = false
-	landed = false
-	linear_damp = 0.1
+        var launch = target_pos - global_position
+        launch.y += 1.0
+        var dir = launch.normalized()
+        linear_velocity = dir * 0.5
+        apply_impulse(Vector3.ZERO, dir * 2.0)
+        apply_torque_impulse(Vector3(0.0, 0.0, -3.0))
+        front_shown = false
+        landed = false
+        linear_damp = 0.1
+        angular_damp = 0.1
 
 func _physics_process(_delta):
-	if not front_shown and rotation_degrees.z < 90.0:
-		front_shown = true
-		_show_front()
-	if not landed and get_contact_count() > 0:
-		landed = true
-		linear_damp = 2.0
+        if not front_shown and rotation_degrees.z < 90.0:
+                front_shown = true
+                _show_front()
+        if not landed and get_contact_count() > 0:
+                landed = true
+                linear_damp = 2.0
+                angular_damp = angular_slide_damp
+                angular_velocity = Vector3.ZERO
 
 
 func _show_front():


### PR DESCRIPTION
## Summary
- stop cards from spinning by increasing angular damp and zeroing angular velocity once they land
- expose `angular_slide_damp` for easy tuning

## Testing
- `godot --version` *(fails: command not found)*
- `gdlint Card3D.gd` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689826c76710832daff8d414d18555b9