### PR TITLE
Orient cards based on spawn offset during flight

### DIFF
--- a/Card3D.gd
+++ b/Card3D.gd
@@ -7,6 +7,7 @@ extends Node3D
 @export var reveal_delay: float = 0.1
 
 var label_assigned := false
+var spawn_pos: Vector3
 
 func _ready():
 	rotation_degrees = Vector3(0, 0, 180)
@@ -14,6 +15,10 @@ func _ready():
 	update_icon()
 
 func fly_to(target_pos: Vector3) -> void:
+	var offset = global_position + (global_position - spawn_pos)
+	look_at(offset, Vector3.UP)
+	rotate_z(deg_to_rad(180))
+
 	var tween = get_tree().create_tween()
 	tween.tween_property(self, "global_position", target_pos, flight_time).set_trans(Tween.TRANS_LINEAR).set_ease(Tween.EASE_IN_OUT)
 	tween.tween_callback(func():

--- a/CardTable.gd
+++ b/CardTable.gd
@@ -144,6 +144,7 @@ func draw_card():
 	if card:
 		card_row.add_child(card)
 		card.global_transform = spawn_transform
+		card.spawn_pos = spawn_transform.origin
 		card.rotation_degrees = Vector3(0, 0, 180)
 		var idx := cards.size()
 		cards.append(card)


### PR DESCRIPTION
## Summary
- orient cards away from their spawn position before flight using `look_at`
- preserve card orientation during travel and flip front when arriving
- record spawn position when drawing cards

## Testing
- `gdlint Card3D.gd CardTable.gd` (fails: Max allowed line length, trailing whitespace, definition order, unused argument)
- `gdformat --check Card3D.gd CardTable.gd` (fails: would reformat files)
- `godot --version` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68a41f1decfc832dad2e7382f60ca948